### PR TITLE
Fix crash of ParticleAbilityWarner in custom games.

### DIFF
--- a/Dota2Cheat/Modules/Hacks/ParticleAbilityWarner.cpp
+++ b/Dota2Cheat/Modules/Hacks/ParticleAbilityWarner.cpp
@@ -60,24 +60,17 @@ void Hacks::ParticleAbilityWarner::ProcessParticleMsg(NetMessageHandle_t* msgHan
 		case AP_PUDGE_MEAT_HOOK:
 		case AP_BANSHEE_CRYPT_SWARM:
 		case AP_MEEPO_EARTHBIND:
-			auto& qParticle = queuedParticleIndexes[msgIndex] = AbilityParticleInfo{
-				.nameIndex = (AbilityParticles)particle.particle_name_index()
+			queuedParticleIndexes[msgIndex] = AbilityParticleInfo{
+				.nameIndex = (AbilityParticles)particle.particle_name_index(),
+				.owner = Interfaces::EntitySystem->GetEntity<CDOTABaseNPC>(
+					NH2IDX(particle.entity_handle_for_modifiers()))
 			};
-
-			if (qParticle.nameIndex == AP_KOTL_ILLUMINATE)
-				qParticle.owner = FindParticleOwner("npc_dota_hero_keeper_of_the_light");
-			else if (qParticle.nameIndex == AP_BANSHEE_CRYPT_SWARM)
-				qParticle.owner = FindParticleOwner("npc_dota_hero_death_prophet");
-			else if (qParticle.nameIndex == AP_MEEPO_EARTHBIND)
-				qParticle.owner = FindParticleOwner("npc_dota_hero_meepo");
-
-
 			break;
 		}
 
 		break;
 	}
-										   // Gets the ability owner and determines if the ability trajectory will be drawn
+		// Gets the ability owner and determines if the ability trajectory will be drawn
 	case GAME_PARTICLE_MANAGER_EVENT_UPDATE_ENT:
 	{
 		if (!queuedParticleIndexes.count(msgIndex))
@@ -141,15 +134,15 @@ void Hacks::ParticleAbilityWarner::ProcessParticleMsg(NetMessageHandle_t* msgHan
 						AbilityIndexes.at(info.nameIndex)
 					]->GetEffectiveCastRange();
 
-						if (info.nameIndex == AP_BANSHEE_CRYPT_SWARM)
-							castRange += 390; // hits past its cast range, for some reason
+				if (info.nameIndex == AP_BANSHEE_CRYPT_SWARM)
+					castRange += 390; // hits past its cast range, for some reason
 
-						auto ratio = castRange / cpVal.Length2D();
-						auto enlargedVec = cpVal.To<Vector2D>() * ratio;
-						info.end = info.begin;
-						info.end.x += enlargedVec.x;
-						info.end.y += enlargedVec.y;
-						TrackedAbilityParticles[msgIndex].trajectory = DrawTrajectory(info.begin, info.end);
+				auto ratio = castRange / cpVal.Length2D();
+				auto enlargedVec = cpVal.To<Vector2D>() * ratio;
+				info.end = info.begin;
+				info.end.x += enlargedVec.x;
+				info.end.y += enlargedVec.y;
+				TrackedAbilityParticles[msgIndex].trajectory = DrawTrajectory(info.begin, info.end);
 			}
 			break;
 		case AP_MEEPO_EARTHBIND:
@@ -159,7 +152,7 @@ void Hacks::ParticleAbilityWarner::ProcessParticleMsg(NetMessageHandle_t* msgHan
 				info.end = cpVal;
 				auto& data = TrackedAbilityParticles[msgIndex];
 				data.trajectory = DrawTrajectory(info.begin, info.end);
-				data.aoe = DrawRadius(info.end, info.owner->GetAbilities()[0]->GetAOERadius());
+				data.aoe = DrawRadius(info.end, static_cast<float>(info.owner->GetAbilities()[0]->GetAOERadius()));
 				Modules::ParticleGC.SetDieTime(data.trajectory, 3);
 				Modules::ParticleGC.SetDieTime(data.aoe, 3);
 			}


### PR DESCRIPTION
Get the owner entity handle directly in the protobuf message of create_particle, instead of traversing the entity list by hero name. This prevents crashes in games like OMG.