### PR TITLE
Added Windows 11 21H2 and 22H2 Support on Dota2Loader

### DIFF
--- a/Dota2Loader/include/3rd_party/VersionApi.h
+++ b/Dota2Loader/include/3rd_party/VersionApi.h
@@ -29,6 +29,8 @@ enum eBuildThreshold
     Build_19H1 = 18362,
     Build_19H2 = 18363,
     Build_20H1 = 19041,
+    Build_21H2 = 22000,
+    Build_22H2 = 22621,
     Build_RS_MAX = 99999,
 };
 
@@ -48,6 +50,8 @@ enum eVerShort
     Win10_19H1,     // Windows 10 May 2019 update
     Win10_19H2,     // Windows 10 November 2019 update
     Win10_20H1,     // Windows 10 April 2020 update
+    Win11_21H2,     // Windows 11
+    Win11_22H2      // Windows 11 September 2022 update
 };
 
 struct WinVersion
@@ -109,7 +113,11 @@ BLACKBONE_API inline void InitVersion()
         switch (fullver)
         {
         case _WIN32_WINNT_WIN10:
-            if (g_WinVer.native.dwBuildNumber >= Build_20H1)
+            if (g_WinVer.native.dwBuildNumber >= Build_22H2)
+                g_WinVer.ver = Win11_22H2;
+            else if (g_WinVer.native.dwBuildNumber >= Build_21H2)
+                g_WinVer.ver = Win11_21H2;
+            else if (g_WinVer.native.dwBuildNumber >= Build_20H1)
                 g_WinVer.ver = Win10_20H1;
             else if (g_WinVer.native.dwBuildNumber >= Build_19H2)
                 g_WinVer.ver = Win10_19H2;
@@ -304,6 +312,18 @@ IsWindows1020H1OrGreater()
 }
 
 VERSIONHELPERAPI
+IsWindows1121H2OrGreater()
+{
+    return IsWindowsVersionOrGreater( HIBYTE( _WIN32_WINNT_WIN10 ), LOBYTE( _WIN32_WINNT_WIN10 ), 0, Build_21H2);
+}
+
+VERSIONHELPERAPI
+IsWindows1122H2OrGreater()
+{
+    return IsWindowsVersionOrGreater( HIBYTE( _WIN32_WINNT_WIN10 ), LOBYTE( _WIN32_WINNT_WIN10 ), 0, Build_22H2 );
+}
+
+VERSIONHELPERAPI
 IsWindowsServer()
 {
     OSVERSIONINFOEXW osvi = { sizeof( osvi ), 0, 0, 0, 0, { 0 }, 0, 0, 0, VER_NT_WORKSTATION };
@@ -311,4 +331,3 @@ IsWindowsServer()
 
     return !VerifyVersionInfoW( &osvi, VER_PRODUCT_TYPE, dwlConditionMask );
 }
-

--- a/Dota2Loader/include/BlackBone/Symbols/PatternLoader.cpp
+++ b/Dota2Loader/include/BlackBone/Symbols/PatternLoader.cpp
@@ -69,7 +69,41 @@ void FindPattern( const ScanParams& scan32, const ScanParams& scan64, const Offs
 /// <param name="result">Result</param>
 void OSFillPatterns( std::unordered_map<ptr_t*, OffsetData>& patterns, SymbolData& result )
 {
-    if (IsWindows10RS3OrGreater())
+    if (IsWindows1121H2OrGreater())
+    {
+        // LdrpHandleTlsData64
+        // 41 55 41 56 41 57 48 81 EC F0 00 00
+        patterns.emplace(&result.LdrpHandleTlsData64, OffsetData{ "\x41\x55\x41\x56\x41\x57\x48\x81\xEC\xF0\x00\x00", true, 0xf });
+
+        // RtlInsertInvertedFunctionTable64
+        // 48 89 5C 24 08 57 48 83 EC 30 8B DA
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable64, OffsetData{ "\x48\x89\x5C\x24\x08\x57\x48\x83\xEC\x30\x8B\xDA", true, 0 });
+
+        // RtlpInsertInvertedFunctionTableEntry64
+        // 49 8B E8 48 8B FA 0F 84
+        patterns.emplace(&result.LdrpInvertedFunctionTable64, OffsetData{ "\x49\x8b\xe8\x48\x8b\xfa\x0f\x84", true, -1, -0xF, 2, 6 });
+
+        // RtlInsertInvertedFunctionTable32
+        // 53 56 57 8D 45 F8 8B FA
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable32, OffsetData{ "\x53\x56\x57\x8d\x45\xf8\x8b\xfa", false, 0x8 });
+
+        // RtlpInsertInvertedFunctionTableEntry32
+        // 33 F6 46 3B C6
+        patterns.emplace(&result.LdrpInvertedFunctionTable32, OffsetData{ "\x33\xF6\x46\x3B\xC6", false, -1, -0x1B });
+
+        // LdrpHandleTlsData32
+        // 33 f6 85 c0 79 03
+        auto offset = 0x2c;
+        if (IsWindows1122H2OrGreater())
+            offset = 0x42;
+
+        patterns.emplace(&result.LdrpHandleTlsData32, OffsetData{ "\x33\xf6\x85\xc0\x79\x03", false, offset });
+
+        // LdrProtectMrdata
+        // 75 20 85 f6 75 35
+        patterns.emplace(&result.LdrProtectMrdata, OffsetData{ "\x75\x20\x85\xf6\x75\x35", false, 0x1d });
+    }
+    else if (IsWindows10RS3OrGreater())
     {
         // LdrpHandleTlsData
         // 74 33 44 8D 43 09


### PR DESCRIPTION
Applied the patches from https://github.com/paulhobbel/Blackbone/tree/fix/win11_patterns to Blackbone in order to properly inject DLLs on `Windows 11 21H2` and `Windows 11 22H2`

Additionally, you might need to include the `DIA` DLLs from https://github.com/DarthTon/Blackbone/tree/master/DIA/x64 if you are compiling for `x64`, it might not inject properly in `Windows 11` if these DLLs are not included in the executable folder.